### PR TITLE
Install DST Root CA X3 certificate with trusted CA flag

### DIFF
--- a/setup-le.sh
+++ b/setup-le.sh
@@ -5,7 +5,7 @@ WORKDIR="/root/ipa-le"
 
 dnf install letsencrypt -y
 
-ipa-cacert-manage install "$WORKDIR/ca/isrgrootx1.pem" -n ISRGRootX1 -t ,,
+ipa-cacert-manage install "$WORKDIR/ca/DSTRootCAX3.pem" -n DSTRootCAX3 -t C,,
 ipa-certupdate -v
 
 ipa-cacert-manage install "$WORKDIR/ca/LetsEncryptAuthorityX3.pem" -n letsencryptx3 -t C,,


### PR DESCRIPTION
The certificates in the repo are signed by DTS Root CA X3, not
ISRG Root X1. This would cause issues with unknown issuer. Install
DST Root CA X3 instead of ISRG Root X1 into nssdb to resolve this.

The DST Root CA X3 also has to be marked as trusted CA in order
for the verification of certutil to pass.

Fixes freeipa/freeipa-letsencrypt#1