### PR TITLE
Move from mod_nss to mod_ssl

### DIFF
--- a/renew-le.sh
+++ b/renew-le.sh
@@ -3,16 +3,20 @@ set -o nounset -o errexit
 
 WORKDIR="/root/ipa-le"
 EMAIL=""
-#cd "$WORKDIR"
 
 ### cron
 # check that the cert will last at least 2 days from now to prevent too frequent renewal
 # comment out this line for the first run
 if [ "${1:-renew}" != "--first-time" ]
 then
-	certutil -d /etc/httpd/alias/ -V -u V -n Server-Cert -b "$(date '+%y%m%d%H%M%S%z' --date='2 days')" && exit 0
+	start_timestamp=`date +%s --date="$(openssl x509 -startdate -noout -in /var/lib/ipa/certs/httpd.crt | cut -d= -f2)"`
+	now_timestamp=`date +%s`
+	let diff=($now_timestamp-$start_timestamp)/86400
+	if [ "$diff" -lt "2" ]; then
+		exit 0
+	fi
 fi
-
+cd "$WORKDIR"
 # cert renewal is needed if we reached this line
 
 # cleanup
@@ -20,7 +24,7 @@ rm -f "$WORKDIR"/*.pem
 rm -f "$WORKDIR"/httpd-csr.*
 
 # generate CSR
-certutil -R -d /etc/httpd/alias/ -k Server-Cert -f /etc/httpd/alias/pwdfile.txt -s "CN=$(hostname -f)" --extSAN "dns:$(hostname -f)" -o "$WORKDIR/httpd-csr.der"
+openssl req -new -sha256 -config "$WORKDIR/ipa-httpd.cnf"  -key /var/lib/ipa/private/httpd.key -out "$WORKDIR/httpd-csr.der"
 
 # httpd process prevents letsencrypt from working, stop it
 service httpd stop
@@ -28,10 +32,10 @@ service httpd stop
 # get a new cert
 letsencrypt certonly --standalone --csr "$WORKDIR/httpd-csr.der" --email "$EMAIL" --agree-tos
 
-# remove old cert
-certutil -D -d /etc/httpd/alias/ -n Server-Cert
-# add the new cert
-certutil -A -d /etc/httpd/alias/ -n Server-Cert -t u,u,u -a -i "$WORKDIR/0000_cert.pem"
+# replace the cert
+cp /var/lib/ipa/certs/httpd.crt /var/lib/ipa/certs/httpd.crt.bkp
+mv -f "$WORKDIR/0000_cert.pem" /var/lib/ipa/certs/httpd.crt
+restorecon -v /var/lib/ipa/certs/httpd.crt
 
 # start httpd with the new cert
 service httpd start


### PR DESCRIPTION
Convert all operations with certutil to openssl based ones, which are required from FreeIPA 4.7

Fixes: #12 