### PR TITLE
Fixes Issue #18 and already merged Pull Request #23

### DIFF
--- a/renew-le.sh
+++ b/renew-le.sh
@@ -25,7 +25,7 @@ rm -f "$WORKDIR"/httpd-csr.*
 
 # generate CSR
 OPENSSL_PASSWD_FILE="/var/lib/ipa/passwds/$HOSTNAME-443-RSA"
-[ -f "$OPENSSL_PASSWD_FILE" ] && OPENSSL_EXTRA_ARGS="-passout file:$OPENSSL_PASSWD_FILE" || OPENSSL_EXTRA_ARGS=""
+[ -f "$OPENSSL_PASSWD_FILE" ] && OPENSSL_EXTRA_ARGS="-passin file:$OPENSSL_PASSWD_FILE" || OPENSSL_EXTRA_ARGS=""
 openssl req -new -sha256 -config "$WORKDIR/ipa-httpd.cnf"  -key /var/lib/ipa/private/httpd.key -out "$WORKDIR/httpd-csr.der" $OPENSSL_EXTRA_ARGS
 
 # httpd process prevents letsencrypt from working, stop it


### PR DESCRIPTION
This should fix both the issues that has already been raised: https://github.com/freeipa/freeipa-letsencrypt/issues/18 and the pull request that have already been merged: https://github.com/freeipa/freeipa-letsencrypt/pull/23.

I just ran into this problem today using with a fresh CentOS 8 installation and the `-passin` trick instead of `-passout` did the job.

If there is anything else, please let me know!

Best regards,
Gustavo.