### PR TITLE
Bug Fixes: 'service' command, OpenSSL '-passin' flag

### DIFF
--- a/renew-le.sh
+++ b/renew-le.sh
@@ -26,7 +26,7 @@ rm -f "$WORKDIR"/httpd-csr.*
 # generate CSR
 OPENSSL_PASSWD_FILE="/var/lib/ipa/passwds/$HOSTNAME-443-RSA"
 [ -f "$OPENSSL_PASSWD_FILE" ] && OPENSSL_EXTRA_ARGS="-passin file:$OPENSSL_PASSWD_FILE" || OPENSSL_EXTRA_ARGS=""
-openssl req -new -sha256 -config "$WORKDIR/ipa-httpd.cnf"  -key /var/lib/ipa/private/httpd.key -out "$WORKDIR/httpd-csr.der" $OPENSSL_EXTRA_ARGS
+openssl req -new -sha256 -config "$WORKDIR/ipa-httpd.cnf" -key /var/lib/ipa/private/httpd.key -out "$WORKDIR/httpd-csr.der" $OPENSSL_EXTRA_ARGS
 
 # httpd process prevents letsencrypt from working, stop it
 if ! command -v service >/dev/null 2>&1; then


### PR DESCRIPTION
* `service` command removed in newer fedora versions. Support added for `systemctl` as a result.
* `-passout` is not a valid OpenSSL command flag in recent versions, replacing it with `-passin` as per #42.